### PR TITLE
Agregar la autenticación en el front

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -25,7 +25,7 @@ export default class App extends Component {
     // bind functions for use un jsx
     this.changeView = this.changeView.bind(this);
   }
-  
+  //No se realiza el login del usuario en el front, hay problemas despues cuando se acceden a otras views desde heroku
   // change view + state depending on event key
   changeView(eventKey) {
     switch (eventKey) {


### PR DESCRIPTION
El código esta muy bien organizado y comentado. En el back end utilizan passport.js y lo configuran completamente, pero en el front no se utiliza. Se mandan códigos fijos lo cual impide acceder a ciertas funcionalidades y manda errores en la consola del navegador.